### PR TITLE
trade: add pool constructor options

### DIFF
--- a/Trade/OrderPool.mqh
+++ b/Trade/OrderPool.mqh
@@ -29,32 +29,43 @@
 //| OrderPoolIter or the macro foreachorder to iterate through an    |
 //| order pool.                                                      |
 //+------------------------------------------------------------------+
-class OrderPool: public OrderMatcher
+interface OrderPool: public OrderMatcher
   {
+   int               total() const;
+   bool              select(int i) const;
+  };
+//+------------------------------------------------------------------+
+//| The pool of orders with supplied predefined matcher              |
+//+------------------------------------------------------------------+
+class OrderPoolMatcher: public OrderPool
+  {
+private:
+   const OrderMatcher *m_om;
 public:
-   virtual int       total() const=0;
-   virtual bool      select(int i) const=0;
-   virtual bool      matches() const=0;
+                     OrderPoolMatcher(const OrderMatcher *m):m_om(m){}
+   virtual bool      matches() const {return m_om?m_om.matches():true;}
   };
 //+------------------------------------------------------------------+
 //| The pool of orders from the Terminal order history tab           |
 //+------------------------------------------------------------------+
-class HistoryPool: public OrderPool
+class HistoryPool: public OrderPoolMatcher
   {
 public:
+                     HistoryPool():OrderPoolMatcher(NULL){}
+                     HistoryPool(const OrderMatcher *m):OrderPoolMatcher(m){}
    int               total() const final {return OrdersHistoryTotal();}
    bool              select(int i) const final {return OrderSelect(i,SELECT_BY_POS,MODE_HISTORY);}
-   virtual bool      matches() const {return true;}
   };
 //+------------------------------------------------------------------+
 //| Currently active orders                                          |
 //+------------------------------------------------------------------+
-class TradingPool: public OrderPool
+class TradingPool: public OrderPoolMatcher
   {
 public:
+                     TradingPool():OrderPoolMatcher(NULL){}
+                     TradingPool(const OrderMatcher *m):OrderPoolMatcher(m){}
    int               total() const final {return OrdersTotal();}
    bool              select(int i) const final {return OrderSelect(i,SELECT_BY_POS,MODE_TRADES);}
-   virtual bool      matches() const {return true;}
   };
 //+------------------------------------------------------------------+
 //| For internal use: iterate through an OrderPool                   |


### PR DESCRIPTION
Changes:
* downgrade `OrderPool` to interface;
* add `OrderPoolMatcher` class;
* introduce `OrderMatcher` optional parameter for `TradingPool` and `HistoryPool` constructors.

These changes don't violate current API and allow to reduce boilerplate code in case of defining `TradingPool` and `HistoryPool` since matching criteria for both are often identical. It can also be useful when defining pools as RAII objects. For example:
``` c++
class MagicAndBuyMatcher: public OrderMatcher
  {
private:
   int               m_magic;
public:
                     MagicAndBuyMatcher(int m):m_magic(m){}
   virtual bool      matches() const {return Order::MagicNumber()==m_magic && Order::Type()==OP_BUY;}
  };
...
// elsewhere
   MagicAndBuyMatcher myMatcher(1337);
   TradingPool tp(&myMatcher);
   HistoryPool hp(&myMatcher);
   foreachorder(tp) {
   ...
   }
```