### PR TITLE
Refactor method calls to fix MQL5 deprecated behavior warnings

### DIFF
--- a/Collection/HashMap.mqh
+++ b/Collection/HashMap.mqh
@@ -63,7 +63,7 @@ public:
 
    int               append(Key key,Value value)
      {
-      int ni=append();
+      int ni=HashEntriesBase<Key>::append();
       m_keys[ni]=key;
       m_values[ni]=value;
       return ni;
@@ -71,7 +71,7 @@ public:
 
    void              unremove(int i,Key key,Value value)
      {
-      unremove(i);
+      HashEntriesBase<Key>::unremove(i);
       m_keys[i]=key;
       m_values[i]=value;
      }


### PR DESCRIPTION
This commit refactors hidden method calls in `HashMap.mqh` to use explicit base class method invocation, addressing MQL5 compiler warnings about deprecated behavior that will be disallowed in future versions. The specific warnings being resolved are for hidden method calls that do not occur when compiling with MQL4, thus maintaining backward compatibility with MQL4 while ensuring future-proof compatibility with MQL5.

The changes are limited to method call semantics and do not alter any functional aspects of the code. By making these updates, the codebase stays compliant with both MQL4 and future MQL5 compiler standards.